### PR TITLE
Add listen_address and rpc_address config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,8 @@ cassandra_trickle_fsync_interval_in_kb: 10240
 cassandra_storage_port: 7000
 cassandra_ssl_storage_port: 7001
 
-cassandra_listen_network_interface: eth0
+cassandra_listen_network_address: ''
+cassandra_listen_network_interface: '{{ ansible_default_ipv4.interface }}'
 #cassandra_listen_interface_prefer_ipv6: false
 #cassandra_broadcast_address: 1.2.3.4
 
@@ -67,7 +68,8 @@ cassandra_native_transport_port: 9042
 
 cassandra_start_rpc: 'false'
 cassandra_rpc_port: 9160
-cassandra_rpc_network_interface: eth0
+cassandra_rpc_network_address: ''
+cassandra_rpc_network_interface: '{{ ansible_default_ipv4.interface }}'
 #cassandra_rpc_interface_prefer_ipv6: 'false'
 #cassandra_rpc_broadcast_address: 1.2.3.4
 cassandra_rpc_keepalive: 'true'

--- a/templates/opt/apache-cassandra/conf/cassandra.yaml.j2
+++ b/templates/opt/apache-cassandra/conf/cassandra.yaml.j2
@@ -496,7 +496,11 @@ ssl_storage_port: {{cassandra_ssl_storage_port}}
 # you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+{% if cassandra_listen_network_address != '' %}
+listen_address: {{cassandra_listen_network_address}}
+{% else %}
 listen_interface: {{cassandra_listen_network_interface}}
+{% endif %}
 {% if cassandra_listen_interface_prefer_ipv6 is defined %}
 listen_interface_prefer_ipv6: {{cassandra_listen_interface_prefer_ipv6}}
 {% endif %}
@@ -574,7 +578,11 @@ start_rpc: {{cassandra_start_rpc}}
 # you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+{% if cassandra_rpc_network_address != '' %}
+rpc_address: {{cassandra_rpc_network_address}}
+{% else %}
 rpc_interface: {{cassandra_rpc_network_interface}}
+{% endif %}
 {% if cassandra_rpc_broadcast_address is defined %}rpc_interface_prefer_ipv6: {{cassandra_rpc_broadcast_address}}
 {% else %}# rpc_interface_prefer_ipv6: false{% endif %}
 


### PR DESCRIPTION
@andrewrothstein 

Hey, thank you for the role & extensive configuration options.

Adding options to specify: listen_address and rpc_address.
Also resolving network interface from ansible facts, since eth0 is usually not available in virtualized machines. 
